### PR TITLE
novel-server: split browserless chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,24 +16,16 @@ COPY . .
 RUN npm run prodbuild
 
 ############################
-# Runtime: Node slim + system Chromium, only the bundle
+# Runtime: Node slim (Chrome runs in separate container)
 ############################
 FROM node:${NODE_VERSION}-slim AS runtime
 WORKDIR /app
 
-# Install Chromium + basic fonts + CA certs
+# Only need CA certs for HTTPS requests
 RUN apt-get update \
-     && apt-get install -y --no-install-recommends \
-     chromium \
-     fonts-noto \
-     fonts-noto-color-emoji \
-     ca-certificates \
-     && rm -rf /var/lib/apt/lists/* \
-     && rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/* /var/cache/* /var/log/*
+     && apt-get install -y --no-install-recommends ca-certificates \
+     && rm -rf /var/lib/apt/lists/*
 
-# Tell Puppeteer to use system Chromium and never try to download its own
-RUN chromium --version || google-chrome --version || true
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PUPPETEER_SKIP_DOWNLOAD=1
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,9 +6,32 @@ services:
       - ./.env
     environment:
       NODE_ENV: production
+      BUILD_TYPE: production
       HOST: 0.0.0.0
       PORT: 3000
+      REDIS_URL: redis://redis:6379
+      BROWSERLESS_WS: ws://chrome:3000
       CORS_ORIGIN: "${NOVEL_CLIENT},${VERCEL_CLIENT}"
     ports:
       - "3000:3000"
+    depends_on:
+      - redis
+      - chrome
     restart: unless-stopped
+
+  chrome:
+    image: ghcr.io/browserless/chromium
+    restart: unless-stopped
+    environment:
+      - MAX_CONCURRENT_SESSIONS=2
+      - CONNECTION_TIMEOUT=60000
+      - TIMEOUT=60000
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:

--- a/src/config/novlove.config.ts
+++ b/src/config/novlove.config.ts
@@ -1,23 +1,31 @@
+const REDIS_TIME_CONFIG = {
+  anHour: 60 * 60,
+  twoHours: 2 * 60 * 60,
+  sixHours: 6 * 60 * 60,
+  sixDays: 6 * 60 * 60,
+  sevenDays: 7 * 24 * 60 * 60,
+};
+
 export const NOVLOVE_CONFIG = {
   home: {
     redis_key: 'novlove:home',
-    ttl_seconds: 60 * 60,
+    ttl_seconds: REDIS_TIME_CONFIG.anHour,
   },
   sort: {
     redis_key: 'novlove:sort',
-    ttl_seconds: 2 * 60 * 60,
+    ttl_seconds: REDIS_TIME_CONFIG.twoHours,
   },
   genre: {
     redis_key: 'novlove:genre',
-    ttl_seconds: 6 * 60 * 60,
+    ttl_seconds: REDIS_TIME_CONFIG.sixHours,
   },
   list: {
     redis_key: 'novlove:list',
-    ttl_seconds: 6 * 60 * 60,
+    ttl_seconds: REDIS_TIME_CONFIG.sixDays,
   },
   detail: {
     redis_key: 'novlove:detail',
-    ttl_seconds: 7 * 24 * 60 * 60,
+    ttl_seconds: REDIS_TIME_CONFIG.sevenDays,
   },
 } as const;
 

--- a/src/plugins/cors.ts
+++ b/src/plugins/cors.ts
@@ -8,6 +8,7 @@ export default fp(async (fastify) => {
       process.env.NOVEL_CLIENT || 'http://localhost:5173',
       process.env.VERCEL_CLIENT || '',
       'http://localhost:4173',
+      'http://127.0.0.1:5173'
     ],
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });

--- a/src/routes/novlove.router.ts
+++ b/src/routes/novlove.router.ts
@@ -8,15 +8,11 @@ import {
   NovelRequest,
 } from '#model/novlove.model.js';
 
-
-
-
 export default async function novloveRoute(fastify: FastifyInstance) {
   const novlove = NovloveController(fastify);
   const debug = NovloveRedisDebugController(fastify);
 
   fastify.get('/novlove', novlove.home);
-
   fastify.get<NovelRequest>('/novlove/novel/:name', novlove.novel);
   fastify.get<ChapterRequest>('/novlove/novel/:name/:chapter', novlove.chapter);
   fastify.get<ListsRequest>('/novlove/:list/:listType', novlove.list);


### PR DESCRIPTION
## SUMMARY

Refactored the architecture to run Chrome (browserless) and Redis as separate Docker containers instead of bundling Chromium inside the Node.js image. This reduces the Node.js image size significantly and improves scalability by allowing Chrome and Redis to be managed independently.

## CHANGES

### Docker Architecture

- Dockerfile: Removed Chromium installation from the Node.js runtime image. Now only installs CA certificates since Chrome runs in a separate container.
- compose.yaml: Added chrome service using ghcr.io/browserless/chromium and redis service using redis:7-alpine. Added service dependencies and environment variables (REDIS_URL, BROWSERLESS_WS).

### Puppeteer Configuration

- src/plugins/puppeteer/puppeteer.utils.ts: Simplified WebSocket endpoint logic to use BROWSERLESS_WS env variable directly. Increased protocol timeout to 60 seconds.

### CORS & Config Cleanup
- src/plugins/cors.ts: Added http://127.0.0.1:5173 as allowed origin for local development.
- src/config/novlove.config.ts: Refactored TTL values into a REDIS_TIME_CONFIG constant for better readability.
- src/routes/novlove.router.ts: Minor code cleanup (removed extra blank lines).

### TESTING

- Run docker compose up --build to start all services
- Verify server starts and connects to both Chrome and Redis containers
- Test API endpoints (e.g., GET http://localhost:3000/api/novel/novlove) and confirm responses return successfully
